### PR TITLE
Force footer to contain floated elements

### DIFF
--- a/resources/scss/theme/layout/_footer.scss
+++ b/resources/scss/theme/layout/_footer.scss
@@ -1,6 +1,7 @@
 #footer {
     padding: 1em 3em;
     background: darken($gray-lighter, 4%);
+    overflow: hidden;
 
     ul {
         margin: 0;


### PR DESCRIPTION
The footer didn't contain all floated elements on smaller devices. This fixes that.
